### PR TITLE
Have Makefile use npm to find JSDOC templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ GLIDESDK=$(GLIDE)/v1
 TEXUS=$(GLIDE)/texus
 FONTCONV=GrxFntConv
 
-JSDOC_TEMPLATES=/home/ilu/.nvm/versions/node/v17.4.0/lib/node_modules/better-docs /home/ilu/.nvm/versions/node/v17.5.0/lib/node_modules/better-docs /usr/lib/node_modules/better-docs
+JSDOC_TEMPLATES ?= $(shell npm root)/better-docs $(shell npm root -g)/better-docs
 
 LIB_DZCOMM	= $(DZCOMMDIR)/lib/djgpp/libdzcom.a
 LIB_MUJS	= $(MUJS)/build/release/libmujs.a
@@ -236,6 +236,7 @@ dostodon: zip
 doc:
 	rm -rf $(DOCDIR)
 	mkdir -p $(DOCDIR)
+	# if this fails add JSDOC_TEMPLATES='<location(s) to look for templates>' to your make invocation
 	for i in $(JSDOC_TEMPLATES); do [ -d $$i ] && cd doc && jsdoc --verbose -t $$i -c jsdoc.conf.json -d ../$(DOCDIR) && break; done
 
 init:


### PR DESCRIPTION
Previously it checked three predefined locations, two of which assume the version of node being used and the home directory of the user, while the other depends on the way the system wide node is installed.

Ex. for me the system npm root is `/usr/local/lib/node_modules`, while the nvm suplied version (via `nvm use node`) is `/home/lily/.nvm/versions/node/v22.2.0/lib/node_modules`
